### PR TITLE
Added support for linux

### DIFF
--- a/pipedream.rb
+++ b/pipedream.rb
@@ -1,13 +1,21 @@
 class Pipedream < Formula
     desc "CLI utility for Pipedream"
     homepage "https://pipedream.com"
-    url "https://cli.pipedream.com/darwin/amd64/0.2.5/pd.zip"
-    sha256 "bd1a23ce2428c0c2e35eb80cf69a6069f70d11f1389a9656a27f8a7c1bdf5f9f"
-  
+
+    on_macos do
+      url "https://cli.pipedream.com/darwin/amd64/0.2.5/pd.zip"
+      sha256 "bd1a23ce2428c0c2e35eb80cf69a6069f70d11f1389a9656a27f8a7c1bdf5f9f"    
+    end
+
+    on_linux do
+      url "https://cli.pipedream.com/linux/amd64/0.2.5/pd.zip"
+      sha256 "50435e78aa93db6490896bea93597f0f0a02a619a9cd6404e47cc757fc1e6279"    
+    end
+
     def install
       bin.install "pd"
-    end
-  
+    end  
+
     def caveats; <<~EOS
       ❤ Thanks for installing the Pipedream CLI! If this is your first time using the CLI, be sure to run `pd login` first.
     EOS


### PR DESCRIPTION
In this version the homebrew formula works for macos or linux.

To test install on linux I worked in a docker container:

```
docker run --rm -it linuxbrew/brew /bin/bash
```

Running these commands:

```
apt-get update
apt-get install -y vim curl
sudo su - linuxbrew
sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
brew create https://cli.pipedream.com/linux/amd64/0.2.5/pd.zip
```
at the prompt enter the formula name as `pipedream`

```
vi /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/pipedream.rb
```

then replace the contents of that file with the new .rb file here, then test installing:

```
brew install --build-from-source --verbose --debug pipedream
pd --version
```

QA might want to check it works for them still on linux and mac.
